### PR TITLE
Improve README formatting and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,47 @@
 # VirtualPetBattleArena
-## Quickstart
 
-Este repositorio contiene un esqueleto inicial de microservicios en Spring Boot y Gradle. Para compilar todos los servicios usa:
+Proyecto de ejemplo compuesto por varios microservicios desarrollados con Spring Boot y Gradle.
 
-```bash
-./gradlew build
-```
+## Requisitos
 
-Puedes iniciar los servicios con `docker-compose up`.
+Para preparar el entorno de desarrollo necesitas instalar:
 
+1. **JDK 21**
+2. **Docker** y **Docker Compose**
+3. **Gradle 8** (opcional si dispones del wrapper)
 
-# Virtual Pet Battle Arena: Proyecto Integral de Java para Dominio Completo del LenguajeTe presento **Virtual Pet Battle Arena**, un proyecto comprehensivo de Java que combina entretenimiento con aprendizaje profundo de todos los conceptos del lenguaje, desde fundamentos hasta arquitecturas empresariales avanzadas. Este sistema de batalla de mascotas virtuales multijugador implementa una arquitectura de microservicios completa, permitiendo practicar desde programación orientada a objetos hasta patrones de diseño complejos en un ambiente local completamente simulado .
+## Configuración de la ambientación
 
-## ¿Por Qué Es La Elección Perfecta?### Temática Entretenida y MotivadoraEl proyecto se centra en un sistema de mascotas virtuales con batallas en tiempo real, incluyendo multijugador con rankings, torneos, sistemas de progresión con evolución de mascotas, competencias por ligas y temporadas, y personalización completa de avatares y estrategias . La temática de juego mantiene el interés mientras se aprenden conceptos técnicos complejos, transformando el aprendizaje en una experiencia inmersiva y divertida .
+1. Clona este repositorio:
+   ```bash
+   git clone https://github.com/tu-usuario/VirtualPetBattleArena.git
+   cd VirtualPetBattleArena
+   ```
+2. Compila todos los servicios con Gradle:
+   ```bash
+   gradle build
+   ```
+3. Inicia el entorno local con Docker Compose:
+   ```bash
+   docker-compose up
+   ```
+   Se crearán los contenedores para cada microservicio y estarán accesibles en los puertos definidos en `docker-compose.yml`.
+4. Accede a `http://localhost:8080` para verificar que la API Gateway está en funcionamiento.
 
-### Cobertura Integral de Conceptos JavaEl proyecto está diseñado específicamente para cubrir todos los aspectos fundamentales y avanzados de Java, incluyendo programación orientada a objetos con herencia múltiple y polimorfismo, patrones de diseño como Factory, Strategy, Observer y Singleton, concurrencia y multithreading con batallas simultáneas, y manejo avanzado de collections, streams y lambdas.### Ambiente Local Completo con SimuladoresLa configuración incluye un entorno de desarrollo completamente local usando Docker Compose para simular todos los servicios externos, incluyendo múltiples bases de datos (PostgreSQL, MongoDB, Redis, InfluxDB), sistemas de mensajería (RabbitMQ, Apache Kafka), herramientas de monitoreo (Prometheus, Grafana), y servicios mock para APIs externas .
+## Microservicios disponibles
 
-## Arquitectura del Proyecto### Estructura de MicroserviciosEl proyecto implementa una arquitectura de microservicios moderna con nueve componentes principales: API Gateway para enrutamiento y autenticación, servicios especializados para usuarios, mascotas, batallas, notificaciones y analytics, frontend web con React/TypeScript, y panel de administración con Thymeleaf. Esta estructura permite practicar conceptos de arquitectura distribuida, comunicación entre servicios, y gestión de estados complejos .### Stack Tecnológico ModernoLa implementación utiliza las tecnologías más populares y demandadas en el ecosistema Java actual, incluyendo Spring Boot 3.x como framework principal, Spring Cloud para arquitectura distribuida, Spring Security para autenticación y autorización, múltiples bases de datos para diferentes casos de uso, y herramientas de testing modernas como JUnit 5, TestNG, Mockito y TestContainers .
+- **api-gateway** – Enrutamiento y autenticación
+- **user-service** – Gestión de usuarios
+- **pet-service** – Administración de mascotas
+- **battle-service** – Lógica de batallas
+- **notification-service** – Envío de notificaciones
+- **analytics-service** – Métricas y análisis
 
-## Conceptos Java en Profundidad### Programación Orientada a Objetos AvanzadaEl sistema implementa jerarquías complejas de mascotas con herencia múltiple, donde cada tipo de mascota (Fuego, Agua, Eléctrico) tiene comportamientos específicos, métodos abstractos para evolución, y sistemas de habilidades personalizadas. La encapsulación se practica mediante la gestión de estados de batalla, mientras que el polimorfismo se aplica en algoritmos de combate dinámicos.### Concurrencia y MultithreadingLa implementación incluye batallas simultáneas usando ThreadPoolExecutor, procesamiento asíncrono de notificaciones con CompletableFuture, operaciones thread-safe con Atomic classes y synchronized blocks, y manejo de estado compartido en batallas multijugador. Estos conceptos se practican en escenarios reales de alta concurrencia donde múltiples usuarios pueden batallar simultáneamente.### Patrones de Diseño en AcciónEl proyecto implementa más de ocho patrones de diseño fundamentales: Factory Pattern para creación de mascotas basada en tipos, Strategy Pattern para diferentes algoritmos de batalla, Observer Pattern para sistema de eventos y notificaciones en tiempo real, Builder Pattern para construcción de objetos complejos de batalla, y Singleton Pattern para gestión de configuraciones globales.
+## Comandos útiles
 
-### Testing Integral y ModernoLa estrategia de testing incluye testing unitario con JUnit 5 y cobertura superior al 80%, testing de integración usando TestContainers para simular servicios reales, testing de performance para validar la concurrencia, y mocking avanzado con Mockito para aislar componentes. Esta aproximación enseña las mejores prácticas de testing en aplicaciones empresariales [30].## Cronograma de Desarrollo Estructurado### Fases de ImplementaciónEl proyecto está organizado en cinco fases bien definidas que abarcan 12 semanas de desarrollo continuo, comenzando con setup y configuración de infraestructura, continuando con implementación de servicios básicos, avanzando hacia funcionalidades complejas como batallas en tiempo real, integrando testing comprehensivo y monitoreo, y finalizando con despliegue y optimización.### Progresión de DificultadCada fase introduce conceptos progresivamente más complejos, permitiendo construir conocimiento sólido desde fundamentos hasta arquitecturas avanzadas, comenzando con entidades básicas y evolucionando hacia sistemas distribuidos complejos, garantizando un aprendizaje estructurado y efectivo.
+- `gradle build` – Compila todos los módulos
+- `gradle test` – Ejecuta las pruebas (si existen)
 
-## Configuración del Entorno Local### Simuladores y Servicios CompletosEl entorno de desarrollo incluye simulación completa de servicios productivos usando Docker Compose, con configuración de múltiples bases de datos (PostgreSQL para datos relacionales, MongoDB para datos de mascotas, Redis para cache y sesiones, InfluxDB para métricas), sistemas de mensajería (RabbitMQ para mensajería asíncrona, Apache Kafka para streaming de eventos), y herramientas de desarrollo (MailHog para testing de emails, WireMock para APIs externas).### Scripts de Desarrollo AutomatizadosLa configuración incluye scripts automatizados para iniciar todos los servicios con un comando, ejecutar suites completas de testing, realizar builds incrementales, y despliegue local simplificado, facilitando el flujo de desarrollo y eliminando fricción en el proceso de aprendizaje.
+## Licencia
 
-## Ejemplos de Código Avanzados### Comunicación en Tiempo RealLa implementación de WebSockets para batallas en tiempo real demuestra conceptos avanzados de programación asíncrona, manejo de estado compartido, y comunicación bidireccional, permitiendo actualizaciones instantáneas de estado de batalla y notificaciones en tiempo real a múltiples participantes.### Repositorios Genéricos y EspecificacionesEl sistema implementa patrones de repositorio genérico con type safety, consultas dinámicas usando Specifications, y operaciones asíncronas con CompletableFuture, demostrando uso avanzado de generics, reflection, y programación funcional en contextos empresariales.## Beneficios y Resultados de Aprendizaje### Habilidades Técnicas DesarrolladasAl completar este proyecto, habrás dominado arquitectura de software con microservicios y API Gateway, desarrollo full-stack con integración frontend-backend, DevOps con containerización y CI/CD, testing comprehensivo incluyendo unit, integration y performance testing, gestión de múltiples tipos de bases de datos, y implementación de comunicación REST, WebSocket y message queues.
-
-### Métricas CuantificablesEl proyecto resulta en 15,000-20,000 líneas de código Java de calidad empresarial, más de 80% de cobertura de testing, nueve microservicios independientes completamente funcionales, más de 50 endpoints REST documentados, y implementación práctica de ocho o más patrones de diseño.
-
-### Preparación ProfesionalEsta experiencia te prepara directamente para roles de desarrollo Java senior, proporcionando conocimiento práctico de arquitecturas empresariales, experiencia con el stack tecnológico más demandado en la industria, y un portfolio project impresionante que demuestra competencia técnica integral.El **Virtual Pet Battle Arena** representa la síntesis perfecta entre entretenimiento y aprendizaje técnico profundo, ofreciendo un proyecto que no solo enseña Java comprehensivamente, sino que también proporciona experiencia práctica con las herramientas y patrones utilizados en desarrollo empresarial moderno. La combinación de temática atractiva, cobertura técnica integral, y ambiente de desarrollo realista hace de este proyecto la elección ideal para dominar Java de manera completa y práctica.
+Distribuido bajo la licencia Apache 2.0.


### PR DESCRIPTION
## Summary
- rework README in Spanish with GitHub-style formatting
- describe prerequisites and detailed environment setup

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_b_6858e5e44cb48330916af527a381aa57