### PR TITLE
Fix gradle instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Para preparar el entorno de desarrollo necesitas instalar:
    git clone https://github.com/tu-usuario/VirtualPetBattleArena.git
    cd VirtualPetBattleArena
    ```
-2. Compila todos los servicios con Gradle:
+2. Compila todos los servicios con Gradle (usando el wrapper incluido):
    ```bash
-   gradle build
+   ./gradlew build      # en Windows usa gradlew.bat
    ```
 3. Inicia el entorno local con Docker Compose:
    ```bash
@@ -39,8 +39,8 @@ Para preparar el entorno de desarrollo necesitas instalar:
 
 ## Comandos útiles
 
-- `gradle build` – Compila todos los módulos
-- `gradle test` – Ejecuta las pruebas (si existen)
+- `./gradlew build` – Compila todos los módulos
+- `./gradlew test` – Ejecuta las pruebas (si existen)
 
 ## Licencia
 


### PR DESCRIPTION
## Summary
- update build steps to use the Gradle wrapper
- clarify windows usage in README

## Testing
- `gradle build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_b_6858e70c4ec08330b773019ef9fc582d